### PR TITLE
Images bytearray fix. Moved to a new ImportFile.

### DIFF
--- a/Examples/StaticWebsite.wls
+++ b/Examples/StaticWebsite.wls
@@ -16,13 +16,13 @@ tcp["MessageHandler", "HTTP"]  = HTTPPacketQ -> http
 Print["Starting HTTP handler"];
 
 http = HTTPHandler[]
-http["MessageHandler", "Index"]  = AssocMatchQ[<|"Path" -> "/"|>] -> Function[ImportFileAsText["index.html"]]
-http["MessageHandler", "File"]  = GetFileRequestQ[{"html", "css", "js", "png", "jpg", "svg"}] -> (ImportFileAsText[#, "Base"->{"", "secret"}]&)
+http["MessageHandler", "Index"]  = AssocMatchQ[<|"Path" -> "/"|>] -> ((StringTemplate[ImportFile["index.html", "StringOutput"->True]][#])&)
+http["MessageHandler", "File"]  = GetFileRequestQ[{"html", "txt", "css", "js", "png", "jpg", "svg"}] -> (ImportFile[#, "Base"->{Directory[], "secret"}]&)
 
 listener = SocketListen[9000, tcp@Echo@#&]
 
 StringTemplate["Open your browser on ``"][URLBuild[<|"Scheme" -> "http", 
-  "Port" -> httplistener["Socket"]["DestinationPort"], 
-  "Domain" -> First[httplistener["Socket"]["DestinationIPAddress"]]|>]] // Print;
+  "Port" -> listener["Socket"]["DestinationPort"], 
+  "Domain" -> First[listener["Socket"]["DestinationIPAddress"]]|>]] // Print;
 
 While[True, Pause[0.001]]

--- a/Kernel/Extensions.wl
+++ b/Kernel/Extensions.wl
@@ -75,81 +75,54 @@ FileNameToURLPath[fileName_String] :=
 URLBuild[FileNameSplit[StringTrim[fileName, StartOfString ~~ Directory[]]]]; 
 
 
-Options[ImportFileAsText] = {"Base" :> {Directory[]}}
+Options[ImportFile] = {"Base" :> {Directory[]}, "StringOutput"->False}
+Options[importFile] = Options[ImportFile]
 
-
-ImportFileAsText[file_String] := 
-If[FileExistsQ[file], 
-    With[{body = Import[file, "String"]},
+importFile[path_String, opts:OptionsPattern[]] := With[{body = ReadByteArray[path]},
+      If[!OptionValue["StringOutput"],
         <|
             "Body" -> body, 
             "Code" -> 200, 
             "Headers" -> <|
-                "Content-Type" -> GetMIMEType[file], 
-                "Content-Length" -> StringLength[body], 
+                "Content-Type" -> GetMIMEType[path], 
+                "Content-Length" -> Length[body], 
                 "Connection"-> "Keep-Alive", 
                 "Keep-Alive" -> "timeout=5, max=1000", 
                 "Cache-Control" -> "max-age=60480"
             |>
-        |> 
-    ], 
-
-        (*Else*)
-            <|"Code" -> 404|>
-        ]
+        |>
+      ,
+        body // ByteArrayToString
+      ] 
     ]
-]; 
+
+ImportFile[file_String, opts:OptionsPattern[]] := Module[{paths = Flatten[OptionValue["Base"]]},
+    
+    With[{path = FileNameJoin[{#, file}]},
+     If[
+         Print["Checking "<>path<>"..."];
+         FileExistsQ[path]
+     ,
+         Return[importFile[path, opts], Module]
+     ]
+    ] &/@ paths;
+
+    Print["file "<>file<>" was not found ;()"];
+
+    <|"Code" -> 404|>
+]
+
 
 
 ImportFile[request_Association, opts: OptionsPattern[]] := 
 ImportFile[URLPathToFileName[request["Path"]], opts]
 
 
-ImportFileAsText[request_Association, OptionsPattern[]] := (
-ImportFileAsText[OptionValue["Base"], URLPathToFileName[request["Path"]]])
-
-ImportFileAsText[name_String] := 
-ImportFileAsText[URLPathToFileName[name], ""]
-
-
-MIMETypes = Uncompress["1:eJytWFlv3DYQTlsH6N0kva+HPhdaxw1co30r0AMF+hT+gIJLURJtUWRIrsT6J/\
-RXd0iudzfirKS1+2Lt0B+HM8M5+d1avaz+\
-ffTokT2DP38J66o376iXm5aTQFFBPgsfrVvBqBOqO9fKOsuM0GP8WxFfkffDd1MKde4LoK\
-sR7CzB2ELcLL94rGXkXfg67t25bqnoUFBFPoRvL0oeeElbwBIK1OTtO25AoBA/\
-zysacEPe28m/\
-plYwjFsvyDs7bkAhmLXUESMkrfk5UBjGJkwUvHGyxTAuWSHx0cau1k5gtg/\
-L88g34MeM7QPFFtwPq+WBhkBhGK0XMLJ2f39AIJCSmcyxfVEKw5lTBtvADfkq2+Avn/\
-9UMFowbrBoKBUjz0abpB2UKRF7A1iS5yN035Ur8K2wZQWAjeSdW0nKjOIdXbe8XF38gPPy\
-5A+El9K88+AXykjqbKGqSjC+YxyO0UYxbq3oatnujkR1c6fo5qZ1c1zCbTq+SDf3v+\
-h2dySmmyv3DuTRMCohZJ/mDoSGLtf2tCxaaU8+2EVC0A1WEFwNEbqPmDoLzkDVt9k1+aK+\
-FeP8EQK5mQ/kZgYTxGpaTT4enTmIruEtlrSaJSENyWwys50lTDub/\
-gRTByYDCsXYaP6UP2jLu5JiOUHwQ/\
-MDhQglam6jelKVvD0PJMapXgLqxLyhrqkhX4xsf017WlDDGtFj3n6teeSb1ACqRvQIy9Oo\
-xGoGFKhrm0noiyDj0Xi4nqlrj+FHCGWfuZ0v4jqikOS2ObB5IJGTpSjjyal+\
-A4VxEqWYBCVGFflonC6zgI1I1UdkagZebQS7cUJiFyf1i6jB9lz8SuT2dhM7BHSWQPU0Kr\
-Gq4s3Fa9hmb8lLQTVlN3Dh6JZFfHVWW7fsIWNfQ0lGN/\
-l7bFpy56qk2VXBGoLUVzJP7DfMXhUSvzF9ZcnX6AYr6o66jUF3lbnvwBoSWrpFkr3mBsuE\
-uqsPshdQiF/oULd/PGJlNXCjlYDaekL11qF6/4ZwnK7e2nAL3wifrt1aU/\
-LtnMSYYJpK8mJWVVqWopvRM4lh7ymGleRqVgzbQkDZRg1LTK5hWPn9oSbfnYgq6+\
-6pLLjXz7PKHkqySF9wsT8fqu8hiap8e7LKMUJPaAUD9cotKAaBMpR8sqsFEPRdYThtI4mI\
-b8DZT4HX6zjGplzhC6AxEU7j6fKsBmso0u/7MSNYE34gOEs1+\
-TJLf7AKbmsc26B7YOj6PN/DDOcdo+\
-MRNPywolXzRcQKifoHSPP3zbASboPPmVY48mkuj9uAs2L+YdtoxF1JHqiGUMUYd+\
-WClwgLFSQfc6tNqEzwP4rr2tcH4wpQ3+\
-Mzkx3oaUO3HarMiGCMRrGbgfa8qI4I5KAJzoczhzbxoWtEsFnPGLGN23fg7sgYEtanUY+\
-3qHYaFk+EtnHfUDv8lSwsT6MiK1tlffc2Y3HPOHq6d/MTR8/\
-SE10aloue0ewJIMEsefIa7Ohc1Zfq4DkMKAwj+\
-oMHuKAHrIyB4UdvtnZO4RpIjJ0ts7BLTC2avMD9DqLJF0AjZw/h0e7pODwH/\
-PFukPn9hIdFyR2tRIv1OgOo9iRjj3olrKbKM8YeHboGfZmlgviIwk0FAXu5usA2mQXG9pC\
-nkbAWbQ+dqqgbV8B/sH1rGZPdXRXya+\
-EkRZGvPV0GbT0eOr6FQriaiIrFDZ9v87F2IrzS4XZNLqcOtw3nbrUWHTX/\
-LOh8gOGMNonhIk6e/\
-IJwmu6hLHRNtIyHyO1hKHPIkBdTYp4wUAAzT359oKQT8wSwmHsL9Hb2udDbWS63QpNvsqi\
-A1YIpGbpRy7G8OozfRv4DUoPZxg=="]//Association
+ImportFileAsText = ImportFile
 
 
 GetMIMEType[file_String] := Module[{type},
-    type = MIMETypes[file // FileExtension];
+    type = $mimeTypes[file // FileExtension];
 	If[!StringQ[type], type = "application/octet-stream"];
     type
 ]; 
@@ -277,7 +250,8 @@ Options[HypertextProcess] = {
 
 HypertextProcess[request_Association, OptionsPattern[]] := Module[{body},
 With[{file = URLPathToFileName[request]}, 
-    Block[{$CurrentRequest = request},
+    Block[{Global`$CurrentRequest = request},
+
         body = LoadPage[file, {}, "Base" -> First@Flatten@{OptionValue["Base"]}];
 
         (* handle special case for redirect *)

--- a/Kernel/Extensions.wl
+++ b/Kernel/Extensions.wl
@@ -48,6 +48,9 @@ ProcessMultipart::usage =
 "ProcessMultipart[request] returns processed request with a POST data decrypted."; 
 
 
+SetMIMETable::usage =
+"SetMIMETable[table_Association] sets a custom MIME types table"
+
 Begin["`Private`"]; 
 
 
@@ -135,6 +138,7 @@ DirectoryName[$InputFileName];
 $mimeTypes = 
 Get[FileNameJoin[{$directory, "MIMETypes.wl"}]];
 
+SetMIMETable[assoc_Association] := $mimeTypes = assoc
 
 GetMIMEType[request_Association] := 
 GetMIMEType[URLPathToFileName[request["Path"]]]; 


### PR DESCRIPTION
- replaced legacy with ImportFile
- Images are imported as a ByteArray by the default (fixed an issue with serializers and non readable data in UTF8)
- StaticWebSite.wls was fixed and now supports StringTemplate


Side effect
- no reason: server works slower ;(